### PR TITLE
PUT maintenanceQuotes (img urls being replaced)

### DIFF
--- a/maintenance.py
+++ b/maintenance.py
@@ -323,6 +323,20 @@ class MaintenanceQuotes(Resource):
             raise BadRequest("Request failed, no UID in payload.")
         key = {'maintenance_quote_uid': payload['maintenance_quote_uid']}
         quote = {k: v for k, v in payload.items()}
+        images = []
+        i = 0
+        while True:
+            filename = f'img_{i}'
+            file = request.files.get(filename)
+            if file:
+                key = f'maintenanceQuotes/{quote["maintenance_quote_uid"]}/{filename}'
+                image = uploadImage(file, key, '')
+                images.append(image)
+            else:
+                break
+            i += 1
+        quote["quote_maintenance_images"] = json.dumps(images)
+
         with connect() as db:
             response = db.update('maintenanceQuotes', key, quote)
         return response


### PR DESCRIPTION
PUT maintenanceQuotes (img urls being replaced)

`Image URLs` are currently being `replaced` in the `SQL` field (quote_maintenance_images). 
The next PR will have these appended after uploading to S3.

`CORS issue with local testing, need to check live endpoint.`