### PR TITLE
status mapping + endpoints cleanup

### DIFF
--- a/maintenance_mapper.py
+++ b/maintenance_mapper.py
@@ -1,75 +1,118 @@
-def mapMaintenanceStatusByUserType(response, user_type):
-    if user_type == 'OWNER':
-        return mapMaintenanceStatusForOwner(response)
-    elif user_type == 'TENANT':
-        return mapMaintenanceStatusForTenant(response)
-    elif user_type == 'MANAGEMENT':
-        return mapMaintenanceStatusForPropertyManager(response)
-    elif user_type == 'MAINTENANCE':
-        return mapMaintenanceStatusForMaintenancePerson(response)
-    return response
-
-
-def mapMaintenanceStatusForOwner(response):
-    status_colors = {
-        'NEW REQUEST': '#A52A2A',
-        'INFO REQUESTED': '#C06A6A',
-        'QUOTES REQUESTED': '#D29494',
-        'PROCESSING': '#3D5CAC',
-        'SCHEDULED': '#3D5CAC',
-        'COMPLETED': '#3D5CAC',
-    }
-
-    mapped_items = {k: {'maintenance_color': v, 'maintenance_items': []} for k, v in status_colors.items()}
+def mapMaintenanceForOwnerOrTenantOrProperty(response, mapped_items):
     for record in response['result']:
-        if record['maintenance_request_status'] == 'NEW':
+        status = record.get('maintenance_request_status')
+        if status == 'NEW':
             mapped_items['NEW REQUEST']['maintenance_items'].append(record)
-        elif record['maintenance_request_status'] == 'INFO':
+        elif status == 'INFO':
             mapped_items['INFO REQUESTED']['maintenance_items'].append(record)
-        elif record['quote_status'] == 'REQUESTED':
-            mapped_items['QUOTES REQUESTED']['maintenance_items'].append(record)
-        elif record['quote_status'] == 'SENT' or record['quote_status'] == 'WITHDRAWN' \
-                or record['quote_status'] == 'REFUSED' or record['quote_status'] == 'REJECTED' \
-                or record['quote_status'] == 'ACCEPTED' or record['quote_status'] == 'SCHEDULE':
-            mapped_items['PROCESSING']['maintenance_items'].append(record)
-        elif record['quote_status'] == 'SCHEDULED' or record['quote_status'] == 'RESCHEDULED':
-            mapped_items['SCHEDULED']['maintenance_items'].append(record)
-        elif record['quote_status'] == 'FINISHED' or record['quote_status'] == 'COMPLETED':
-            mapped_items['COMPLETED']['maintenance_items'].append(record)
+        elif status == 'PROCESSING' or status == 'SCHEDULED' or status == 'CANCELLED' or status == 'COMPLETED':  # for statuses - processing, scheduled, cancelled, completed
+            mapped_items[status]['maintenance_items'].append(record)
 
     response['result'] = mapped_items
     return response
 
+def mapMaintenanceForOwner(response):
+    status_colors = {
+        'NEW REQUEST': '#A52A2A',
+        'INFO REQUESTED': '#C06A6A',
+        # 'QUOTES REQUESTED': '#D29494',  # Deprecated as per new figma
+        'PROCESSING': '#3D5CAC',
+        'SCHEDULED': '#3D5CAC',
+        'CANCELLED': '#TBD',
+        'COMPLETED': '#3D5CAC',
+    }
 
-def mapMaintenanceStatusForTenant(response):
+    mapped_items = {k: {'maintenance_color': v, 'maintenance_items': []} for k, v in status_colors.items()}
+    return mapMaintenanceForOwnerOrTenantOrProperty(response, mapped_items)
+
+
+def mapMaintenanceForTenant(response):
     status_colors = {
         'NEW REQUEST': '#A52A2A',
         'INFO REQUESTED': '#C06A6A',
         'PROCESSING': '#3D5CAC',
         'SCHEDULED': '#3D5CAC',
+        'CANCELLED': '#TBD',
         'COMPLETED': '#3D5CAC',
     }
 
     mapped_items = {k: {'maintenance_color': v, 'maintenance_items': []} for k, v in status_colors.items()}
-    for record in response['result']:
-        if record['maintenance_request_status'] == 'NEW':
-            mapped_items['NEW REQUEST']['maintenance_items'].append(record)
-        elif record['maintenance_request_status'] == 'INFO':
-            mapped_items['INFO REQUESTED']['maintenance_items'].append(record)
-        elif record['quote_status'] == 'SENT' or record['quote_status'] == 'WITHDRAWN' \
-                or record['quote_status'] == 'REFUSED' or record['quote_status'] == 'REJECTED' \
-                or record['quote_status'] == 'ACCEPTED' or record['quote_status'] == 'SCHEDULE':
-            mapped_items['PROCESSING']['maintenance_items'].append(record)
-        elif record['quote_status'] == 'SCHEDULED' or record['quote_status'] == 'RESCHEDULE':
-            mapped_items['SCHEDULED']['maintenance_items'].append(record)
-        elif record['quote_status'] == 'WITHDRAWN' or record['quote_status'] == 'FINISHED' or record['quote_status'] == 'COMPLETED':
-            mapped_items['COMPLETED']['maintenance_items'].append(record)
+    return mapMaintenanceForOwnerOrTenantOrProperty(response, mapped_items)
 
-    response['result'] = mapped_items
-    return response
+def mapMaintenanceForProperty(response):
+    status_colors = {  # there is no figma yet, update # codes
+        'NEW REQUEST': '#A52A2A',
+        'INFO REQUESTED': '#C06A6A',
+        'PROCESSING': '#3D5CAC',
+        'SCHEDULED': '#3D5CAC',
+        'CANCELLED': '#TBD',
+        'COMPLETED': '#3D5CAC',
+    }
+
+    mapped_items = {k: {'maintenance_color': v, 'maintenance_items': []} for k, v in status_colors.items()}
+    return mapMaintenanceForOwnerOrTenantOrProperty(response, mapped_items)
+
+# TODO: Remove comments if new mapping looks good
+# def mapMaintenanceStatusForOwner(response):
+#     status_colors = {
+#         'NEW REQUEST': '#A52A2A',
+#         'INFO REQUESTED': '#C06A6A',
+#         'QUOTES REQUESTED': '#D29494',
+#         'PROCESSING': '#3D5CAC',
+#         'SCHEDULED': '#3D5CAC',
+#         'COMPLETED': '#3D5CAC',
+#     }
+#
+#     mapped_items = {k: {'maintenance_color': v, 'maintenance_items': []} for k, v in status_colors.items()}
+#     for record in response['result']:
+#         if record['maintenance_request_status'] == 'NEW':
+#             mapped_items['NEW REQUEST']['maintenance_items'].append(record)
+#         elif record['maintenance_request_status'] == 'INFO':
+#             mapped_items['INFO REQUESTED']['maintenance_items'].append(record)
+#         elif record['quote_status'] == 'REQUESTED':
+#             mapped_items['QUOTES REQUESTED']['maintenance_items'].append(record)
+#         elif record['quote_status'] == 'SENT' or record['quote_status'] == 'WITHDRAWN' \
+#                 or record['quote_status'] == 'REFUSED' or record['quote_status'] == 'REJECTED' \
+#                 or record['quote_status'] == 'ACCEPTED' or record['quote_status'] == 'SCHEDULE':
+#             mapped_items['PROCESSING']['maintenance_items'].append(record)
+#         elif record['quote_status'] == 'SCHEDULED' or record['quote_status'] == 'RESCHEDULED':
+#             mapped_items['SCHEDULED']['maintenance_items'].append(record)
+#         elif record['quote_status'] == 'FINISHED' or record['quote_status'] == 'COMPLETED':
+#             mapped_items['COMPLETED']['maintenance_items'].append(record)
+#
+#     response['result'] = mapped_items
+#     return response
+#
+#
+# def mapMaintenanceStatusForTenant(response):
+#     status_colors = {
+#         'NEW REQUEST': '#A52A2A',
+#         'INFO REQUESTED': '#C06A6A',
+#         'PROCESSING': '#3D5CAC',
+#         'SCHEDULED': '#3D5CAC',
+#         'COMPLETED': '#3D5CAC',
+#     }
+#
+#     mapped_items = {k: {'maintenance_color': v, 'maintenance_items': []} for k, v in status_colors.items()}
+#     for record in response['result']:
+#         if record['maintenance_request_status'] == 'NEW':
+#             mapped_items['NEW REQUEST']['maintenance_items'].append(record)
+#         elif record['maintenance_request_status'] == 'INFO':
+#             mapped_items['INFO REQUESTED']['maintenance_items'].append(record)
+#         elif record['quote_status'] == 'SENT' or record['quote_status'] == 'WITHDRAWN' \
+#                 or record['quote_status'] == 'REFUSED' or record['quote_status'] == 'REJECTED' \
+#                 or record['quote_status'] == 'ACCEPTED' or record['quote_status'] == 'SCHEDULE':
+#             mapped_items['PROCESSING']['maintenance_items'].append(record)
+#         elif record['quote_status'] == 'SCHEDULED' or record['quote_status'] == 'RESCHEDULE':
+#             mapped_items['SCHEDULED']['maintenance_items'].append(record)
+#         elif record['quote_status'] == 'WITHDRAWN' or record['quote_status'] == 'FINISHED' or record['quote_status'] == 'COMPLETED':
+#             mapped_items['COMPLETED']['maintenance_items'].append(record)
+#
+#     response['result'] = mapped_items
+#     return response
 
 
-def mapMaintenanceStatusForPropertyManager(response):
+def mapMaintenanceForPropertyManager(response):
     status_colors = {
         'NEW REQUEST': '#A52A2A',
         'QUOTES REQUESTED': '#C06A6A',
@@ -100,7 +143,7 @@ def mapMaintenanceStatusForPropertyManager(response):
     return response
 
 
-def mapMaintenanceStatusForMaintenancePerson(response):
+def mapMaintenanceForMaintenance(response):
     status_colors = {
         'REQUESTED': '#DB9687',
         'SUBMITTED': '#D4A387',

--- a/myspace_api.py
+++ b/myspace_api.py
@@ -29,9 +29,9 @@ from profiles import OwnerProfile, OwnerProfileByOwnerUid, TenantProfile, Tenant
 from documents import OwnerDocuments, TenantDocuments
 from leases import LeaseDetails
 from purchases import Bills, AddExpense, AddRevenue, RentPurchase
-from maintenance import MaintenanceStatus, MaintenanceStatusByProperty, MaintenanceByProperty, MaintenanceStatusByOwner, \
-    MaintenanceRequestsByOwner, MaintenanceRequests, MaintenanceReq, MaintenanceRequestCount, MaintenanceSummaryByOwner, MaintenanceStatusByOwnerSimplified, \
-    MaintenanceSummaryAndStatusByOwner, MaintenanceQuotes, MaintenanceQuotesByUid, MaintenanceStatusByProfile, MaintenanceDashboard
+from maintenance import MaintenanceStatus, MaintenanceStatusByProperty, MaintenanceByProperty, \
+    MaintenanceRequestsByOwner, MaintenanceRequests, MaintenanceReq, MaintenanceRequestCount, MaintenanceSummaryByOwner, \
+    MaintenanceSummaryAndStatusByOwner, MaintenanceQuotes, MaintenanceQuotesByUid, MaintenanceDashboard
 from contacts import ContactsMaintenance, ContactsOwnerContactsDetails, ContactsBusinessContacts, ContactsBusinessContactsOwnerDetails, ContactsBusinessContactsTenantDetails, ContactsBusinessContactsMaintenanceDetails, ContactsOwnerManagerDetails, ContactsMaintenanceManagerDetails, ContactsMaintenanceTenantDetails
 from contracts import Contracts, ContractsByBusiness
 from settings import Account
@@ -408,9 +408,6 @@ api.add_resource(PropertyDashboardByOwner,
 
 api.add_resource(MaintenanceStatus, '/maintenanceStatus/<string:uid>')
 
-api.add_resource(MaintenanceStatusByProfile,
-                 '/maintenanceStatus/<string:profile_uid>')
-
 api.add_resource(MaintenanceReq, '/maintenanceReq/<string:uid>')
 api.add_resource(MaintenanceRequestCount, '/maintenanceReqCount/<string:uid>')
 
@@ -421,12 +418,8 @@ api.add_resource(MaintenanceByProperty,
                  '/maintenanceByProperty/<string:property_id>')
 api.add_resource(MaintenanceStatusByProperty,
                  '/maintenanceStatusByProperty/<string:property_id>')
-api.add_resource(MaintenanceStatusByOwner,
-                 '/maintenanceStatusByOwner/<string:owner_id>')
 api.add_resource(MaintenanceSummaryByOwner,
                  '/maintenanceSummaryByOwner/<string:owner_id>')
-api.add_resource(MaintenanceStatusByOwnerSimplified,
-                 '/maintenanceStatusByOwnerSimplified/<string:owner_id>')
 api.add_resource(MaintenanceSummaryAndStatusByOwner,
                  '/maintenanceSummaryAndStatusByOwner/<string:owner_id>')
 


### PR DESCRIPTION
1.) POST /quotes moved to POST /maintenanceQuotes for consistency. (This is assuming that you aren't calling POST /maintenanceQuotes with json data and will always use form data for /maintenanceQuotes)

2.) Removed GET /maintenanceStatusByOwner & GET /maintenanceStatusByOwnerSimplified, we can use GET /maintenanceReq instead. 

3.) I thought we could combine GET maintenanceReq into GET maintenanceReqCount, but we can't because we need to group by status for the second 

4.) We can't move GET maintenanceReq into GET maintenanceRequests (as I had initially thought) because of the endpoint URL as mentioned by Prashant. 

5.) I've made all the required mapping changes. Added a 'cancelled' status and a new mapping for 'property' (which has statuses same as tenant and owner, no figma yet) as mentioned by Prashant.

